### PR TITLE
Development

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:  
   install:  
     runtime-versions: 
-      nodejs: 12     
+      nodejs: 16     
   pre_build:  
     commands:  
       - echo "Installing dependencies and executing unit tests - `pwd`"  

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -892,7 +892,7 @@ export class LiveStreaming extends cdk.Stack {
      const solutionName = 'Live Streaming on AWS';
      const applicationName = `live-streaming-on-aws-${cdk.Aws.STACK_NAME}`;
      const attributeGroup = new appreg.AttributeGroup(this, 'AppRegistryAttributeGroup', {
-         attributeGroupName: cdk.Aws.STACK_NAME,
+         attributeGroupName: `${cdk.Aws.REGION}-${cdk.Aws.STACK_NAME}`,
          description: "Attribute group for solution information.",
          attributes: {
              ApplicationType: 'AWS-Solutions',

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -621,7 +621,7 @@ export class LiveStreaming extends cdk.Stack {
      * CloudFront Distribution
      */
     // Need Unique name for each Cache Policy. 
-    const cachePolicyName = `CachePolicy-${cdk.Aws.STACK_NAME}`;
+    const cachePolicyName = `CachePolicy-${cdk.Aws.STACK_NAME}-${cdk.Aws.REGION}`;
 
     const cachePolicy = new cloudfront.CachePolicy(this, `CachePolicy`, {
       cachePolicyName: cachePolicyName,

--- a/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
+++ b/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
@@ -816,6 +816,10 @@ Object {
                 Object {
                   Ref: AWS::StackName,
                 },
+                -,
+                Object {
+                  Ref: AWS::Region,
+                },
               ],
             ],
           },


### PR DESCRIPTION
*Issue #, if available:*
AppRegistry updates

*Description of changes:*
AppRegistry bug: Attribute group name can not start with AWS
Make the region name come first on app registry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
