### PR TITLE
Feature/v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
+## [4.2.1] - 2023-4-17
+### Changed
+- Updated object ownership configuration on the CloudFormation logging bucket.
+- Updated aws-cloudfront-s3 construct to support new bucket ACL changes.
 ## [4.2.0] - 2023-4-10
 
 ### New

--- a/source/constructs/cdk.json
+++ b/source/constructs/cdk.json
@@ -2,6 +2,7 @@
   "app": "npx ts-node bin/live-streaming.ts",
   "context": {
     "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true"
+    "@aws-cdk/core:stackRelativeExports": "true",
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true
   }
 }

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -690,9 +690,9 @@ export class LiveStreaming extends cdk.Stack {
           id: 'AwsSolutions-CFR2',
           reason: 'Use case does not warrant CloudFront integration with AWS WAF'
         }, {
-            id: 'AwsSolutions-CFR3', //same as cfn_nag rule W70
-            reason: 'S3 update causing deploy fail when bucket makes any sort of ACL. With this error cannot have ACLs set with ObjectOwnerships BucketOwnerEnforced setting'
-        },{
+            id: 'AwsSolutions-CFR3',
+            reason: 'S3 changing ownership have to remove since it is causing solution not to deploy'
+        }, {
           id: 'AwsSolutions-CFR4', //same as cfn_nag rule W70
           reason: 'CloudFront automatically sets the security policy to TLSv1 when the distribution uses the CloudFront domain name'
         }, {
@@ -737,13 +737,16 @@ export class LiveStreaming extends cdk.Stack {
         ]
       },
       bucketProps: {
-        versioned: false
+        versioned: false,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER
       },
       loggingBucketProps: {
-        versioned: false
+        versioned: false,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER
       },
       cloudFrontLoggingBucketProps: {
-        versioned: false
+        versioned: false,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER
       },
       insertHttpSecurityHeaders: false
     });

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -577,50 +577,6 @@ export class LiveStreaming extends cdk.Stack {
 
 
     /**
-     * S3: Logs bucket for CloudFront
-     */
-    const logsBucket = new s3.Bucket(this, 'LogsBucket', {
-      enforceSSL: true,
-      versioned: true,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
-      accessControl: s3.BucketAccessControl.LOG_DELIVERY_WRITE,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      blockPublicAccess: {
-        blockPublicAcls: true,
-        blockPublicPolicy: true,
-        ignorePublicAcls: true,
-        restrictPublicBuckets: true
-      }
-    });
-    /** get the cfn resource and attach cfn_nag rule */
-    (logsBucket.node.defaultChild as cdk.CfnResource).cfnOptions.metadata = {
-      cfn_nag: {
-        rules_to_suppress: [
-          {
-            id: 'W35',
-            reason: 'Used to store access logs for other buckets'
-          }, {
-            id: 'W51',
-            reason: 'Bucket is private and does not need a bucket policy'
-          }
-        ]
-      }
-    };
-    //cdk_nag
-    NagSuppressions.addResourceSuppressions(
-      logsBucket,
-      [
-        {
-          id: 'AwsSolutions-S1', //same as cfn_nag rule W35
-          reason: 'Used to store access logs for other buckets'
-        }, {
-          id: 'AwsSolutions-S10',
-          reason: 'Bucket is private and is not using HTTP'
-        }
-      ]
-    );
-
-    /**
      * CloudFront Distribution
      */
     // Need Unique name for each Cache Policy. 
@@ -697,7 +653,6 @@ export class LiveStreaming extends cdk.Stack {
         cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD_OPTIONS
       },
       enabled: true,
-      logBucket: logsBucket,
       logFilePrefix: 'cloudfront-logs/',
       errorResponses: [
         errorResponse400,
@@ -1009,12 +964,6 @@ export class LiveStreaming extends cdk.Stack {
       description: 'Demo bucket',
       value: `https://${cdk.Aws.REGION}.console.aws.amazon.com/s3/buckets/${demoDistribution.s3Bucket?.bucketName}?region=${cdk.Aws.REGION}`,
       exportName: `${cdk.Aws.STACK_NAME}-DemoBucket`
-    });
-
-    new cdk.CfnOutput(this, 'LogsBucketConsole', { // NOSONAR
-      description: 'Logs bucket',
-      value: `https://${cdk.Aws.REGION}.console.aws.amazon.com/s3/buckets/${logsBucket.bucketName}?region=${cdk.Aws.REGION}`,
-      exportName: `${cdk.Aws.STACK_NAME}-LogsBucket`
     });
 
     new cdk.CfnOutput(this, 'AppRegistryConsole', { // NOSONAR

--- a/source/constructs/lib/live-streaming.ts
+++ b/source/constructs/lib/live-streaming.ts
@@ -690,6 +690,9 @@ export class LiveStreaming extends cdk.Stack {
           id: 'AwsSolutions-CFR2',
           reason: 'Use case does not warrant CloudFront integration with AWS WAF'
         }, {
+            id: 'AwsSolutions-CFR3', //same as cfn_nag rule W70
+            reason: 'S3 update causing deploy fail when bucket makes any sort of ACL. With this error cannot have ACLs set with ObjectOwnerships BucketOwnerEnforced setting'
+        },{
           id: 'AwsSolutions-CFR4', //same as cfn_nag rule W70
           reason: 'CloudFront automatically sets the security policy to TLSv1 when the distribution uses the CloudFront domain name'
         }, {

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@aws-cdk/aws-servicecatalogappregistry-alpha": "2.35.0-alpha.0",
-    "@aws-solutions-constructs/aws-cloudfront-s3": "2.35.0",
-    "aws-cdk-lib": "2.68.0",
+    "@aws-solutions-constructs/aws-cloudfront-s3": "2.38.0",
+    "aws-cdk-lib": "2.74.0",
     "cdk-nag": "^2.21.52",
     "constructs": "10.1.283",
     "source-map-support": "0.5.19"

--- a/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
+++ b/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
@@ -4,8 +4,8 @@ exports[`LiveStreaming Stack Test 1`] = `
 Object {
   Description: (SO0013) Live Streaming on AWS Solution %%VERSION%%,
   Mappings: Object {
-    AnonymousData: Object {
-      SendAnonymousData: Object {
+    AnonymizedData: Object {
+      SendAnonymizedData: Object {
         Data: Yes,
       },
     },
@@ -335,41 +335,6 @@ Object {
         ],
       },
     },
-    LogsBucketConsole: Object {
-      Description: Logs bucket,
-      Export: Object {
-        Name: Object {
-          Fn::Join: Array [
-            ,
-            Array [
-              Object {
-                Ref: AWS::StackName,
-              },
-              -LogsBucket,
-            ],
-          ],
-        },
-      },
-      Value: Object {
-        Fn::Join: Array [
-          ,
-          Array [
-            https://,
-            Object {
-              Ref: AWS::Region,
-            },
-            .console.aws.amazon.com/s3/buckets/,
-            Object {
-              Ref: LogsBucket9C4D8843,
-            },
-            ?region=,
-            Object {
-              Ref: AWS::Region,
-            },
-          ],
-        ],
-      },
-    },
     MediaLiveChannelConsole: Object {
       Description: MediaLive Channel,
       Export: Object {
@@ -652,8 +617,8 @@ Object {
         Resource: AnonymousMetric,
         SendAnonymousMetric: Object {
           Fn::FindInMap: Array [
-            AnonymousData,
-            SendAnonymousData,
+            AnonymizedData,
+            SendAnonymizedData,
             Data,
           ],
         },
@@ -677,7 +642,7 @@ Object {
     },
     AppRegistryApp5349BE86: Object {
       DependsOn: Array [
-        AppRegistryAttributeGroup7AF07446,
+        AppRegistryAttributeIdDF43F316,
       ],
       Properties: Object {
         Description: Service Catalog application to track and manage all your resources. The SolutionId is SO0013 and SolutionVersion is %%VERSION%%.,
@@ -704,9 +669,9 @@ Object {
       },
       Type: AWS::ServiceCatalogAppRegistry::Application,
     },
-    AppRegistryAppAttributeGroupAssociation73c027e3f10e9676CFD5: Object {
+    AppRegistryAppAttributeGroupAssociatione6a1c2e3176a77F7002D: Object {
       DependsOn: Array [
-        AppRegistryAttributeGroup7AF07446,
+        AppRegistryAttributeIdDF43F316,
       ],
       Properties: Object {
         Application: Object {
@@ -717,7 +682,7 @@ Object {
         },
         AttributeGroup: Object {
           Fn::GetAtt: Array [
-            AppRegistryAttributeGroup7AF07446,
+            AppRegistryAttributeIdDF43F316,
             Id,
           ],
         },
@@ -726,7 +691,7 @@ Object {
     },
     AppRegistryAppResourceAssociationbb30b2b6ffac2CF098B8: Object {
       DependsOn: Array [
-        AppRegistryAttributeGroup7AF07446,
+        AppRegistryAttributeIdDF43F316,
       ],
       Properties: Object {
         Application: Object {
@@ -742,7 +707,7 @@ Object {
       },
       Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation,
     },
-    AppRegistryAttributeGroup7AF07446: Object {
+    AppRegistryAttributeIdDF43F316: Object {
       Properties: Object {
         Attributes: Object {
           ApplicationType: AWS-Solutions,
@@ -755,6 +720,7 @@ Object {
           Fn::Join: Array [
             ,
             Array [
+              A30-,
               Object {
                 Ref: AWS::Region,
               },
@@ -770,36 +736,6 @@ Object {
         },
       },
       Type: AWS::ServiceCatalogAppRegistry::AttributeGroup,
-    },
-    ApplicationInsightsApp: Object {
-      DependsOn: Array [
-        AppRegistryAppAttributeGroupAssociation73c027e3f10e9676CFD5,
-        AppRegistryApp5349BE86,
-        AppRegistryAppResourceAssociationbb30b2b6ffac2CF098B8,
-      ],
-      Properties: Object {
-        AutoConfigurationEnabled: true,
-        CWEMonitorEnabled: true,
-        OpsCenterEnabled: true,
-        ResourceGroupName: Object {
-          Fn::Join: Array [
-            ,
-            Array [
-              AWS_AppRegistry_Application-live-streaming-on-aws-,
-              Object {
-                Ref: AWS::StackName,
-              },
-            ],
-          ],
-        },
-        Tags: Array [
-          Object {
-            Key: SolutionId,
-            Value: SO0013,
-          },
-        ],
-      },
-      Type: AWS::ApplicationInsights::Application,
     },
     CachePolicy26D8A535: Object {
       Properties: Object {
@@ -1006,15 +942,6 @@ Object {
           Enabled: true,
           HttpVersion: http2,
           IPV6Enabled: true,
-          Logging: Object {
-            Bucket: Object {
-              Fn::GetAtt: Array [
-                LogsBucket9C4D8843,
-                RegionalDomainName,
-              ],
-            },
-            Prefix: cloudfront-logs/,
-          },
           Origins: Array [
             Object {
               CustomOriginConfig: Object {
@@ -1511,9 +1438,9 @@ Object {
           S3Bucket: Object {
             Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region},
           },
-          S3Key: 73d45459ae7abbe57b24ae45648c26887c578dbcc2c8001b8932715b29560f21.zip,
+          S3Key: 700e39bdce00113c2e39b58cb30fec1590a50aa9faf6201ab10f1f7444451b8d.zip,
         },
-        Description: Used to deploy custom resources and send AnonymousData,
+        Description: Used to deploy custom resources and send AnonymizedData,
         Environment: Object {
           Variables: Object {
             SOLUTION_IDENTIFIER: AwsSolution/SO0013/%%VERSION%%,
@@ -1931,61 +1858,6 @@ Object {
         ],
       },
       Type: AWS::IAM::Policy,
-    },
-    LogsBucket9C4D8843: Object {
-      DeletionPolicy: Retain,
-      Metadata: Object {
-        cdk_nag: Object {
-          rules_to_suppress: Array [
-            Object {
-              id: AwsSolutions-S1,
-              reason: Used to store access logs for other buckets,
-            },
-            Object {
-              id: AwsSolutions-S10,
-              reason: Bucket is private and is not using HTTP,
-            },
-          ],
-        },
-        cfn_nag: Object {
-          rules_to_suppress: Array [
-            Object {
-              id: W35,
-              reason: Used to store access logs for other buckets,
-            },
-            Object {
-              id: W51,
-              reason: Bucket is private and does not need a bucket policy,
-            },
-          ],
-        },
-      },
-      Properties: Object {
-        AccessControl: LogDeliveryWrite,
-        BucketEncryption: Object {
-          ServerSideEncryptionConfiguration: Array [
-            Object {
-              ServerSideEncryptionByDefault: Object {
-                SSEAlgorithm: AES256,
-              },
-            },
-          ],
-        },
-        PublicAccessBlockConfiguration: Object {
-          BlockPublicAcls: true,
-          BlockPublicPolicy: true,
-          IgnorePublicAcls: true,
-          RestrictPublicBuckets: true,
-        },
-        Tags: Array [
-          Object {
-            Key: SolutionId,
-            Value: SO0013,
-          },
-        ],
-      },
-      Type: AWS::S3::Bucket,
-      UpdateReplacePolicy: Retain,
     },
     MediaLiveChannel: Object {
       DeletionPolicy: Delete,

--- a/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
+++ b/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
@@ -335,6 +335,41 @@ Object {
         ],
       },
     },
+    LogsBucketConsole: Object {
+      Description: Logs bucket,
+      Export: Object {
+        Name: Object {
+          Fn::Join: Array [
+            ,
+            Array [
+              Object {
+                Ref: AWS::StackName,
+              },
+              -LogsBucket,
+            ],
+          ],
+        },
+      },
+      Value: Object {
+        Fn::Join: Array [
+          ,
+          Array [
+            https://,
+            Object {
+              Ref: AWS::Region,
+            },
+            .console.aws.amazon.com/s3/buckets/,
+            Object {
+              Ref: LogsBucket9C4D8843,
+            },
+            ?region=,
+            Object {
+              Ref: AWS::Region,
+            },
+          ],
+        ],
+      },
+    },
     MediaLiveChannelConsole: Object {
       Description: MediaLive Channel,
       Export: Object {
@@ -942,6 +977,15 @@ Object {
           Enabled: true,
           HttpVersion: http2,
           IPV6Enabled: true,
+          Logging: Object {
+            Bucket: Object {
+              Fn::GetAtt: Array [
+                LogsBucket9C4D8843,
+                RegionalDomainName,
+              ],
+            },
+            Prefix: cloudfront-logs/,
+          },
           Origins: Array [
             Object {
               CustomOriginConfig: Object {
@@ -1134,6 +1178,13 @@ Object {
               ServerSideEncryptionByDefault: Object {
                 SSEAlgorithm: AES256,
               },
+            },
+          ],
+        },
+        OwnershipControls: Object {
+          Rules: Array [
+            Object {
+              ObjectOwnership: ObjectWriter,
             },
           ],
         },
@@ -1337,7 +1388,6 @@ Object {
         },
       },
       Properties: Object {
-        AccessControl: LogDeliveryWrite,
         BucketEncryption: Object {
           ServerSideEncryptionConfiguration: Array [
             Object {
@@ -1404,6 +1454,42 @@ Object {
                 },
               ],
             },
+            Object {
+              Action: s3:PutObject,
+              Condition: Object {
+                ArnLike: Object {
+                  aws:SourceArn: Object {
+                    Fn::GetAtt: Array [
+                      CloudFrontToS3S3Bucket9CE6AB04,
+                      Arn,
+                    ],
+                  },
+                },
+                StringEquals: Object {
+                  aws:SourceAccount: Object {
+                    Ref: AWS::AccountId,
+                  },
+                },
+              },
+              Effect: Allow,
+              Principal: Object {
+                Service: logging.s3.amazonaws.com,
+              },
+              Resource: Object {
+                Fn::Join: Array [
+                  ,
+                  Array [
+                    Object {
+                      Fn::GetAtt: Array [
+                        CloudFrontToS3S3LoggingBucketEF5CD8B2,
+                        Arn,
+                      ],
+                    },
+                    /*,
+                  ],
+                ],
+              },
+            },
           ],
           Version: 2012-10-17,
         },
@@ -1438,7 +1524,7 @@ Object {
           S3Bucket: Object {
             Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region},
           },
-          S3Key: 700e39bdce00113c2e39b58cb30fec1590a50aa9faf6201ab10f1f7444451b8d.zip,
+          S3Key: 09e61b0d6b987f1e34c37dca7fac2021462b7b3bd89ecf3fcdc0eccdae4d6b4a.zip,
         },
         Description: Used to deploy custom resources and send AnonymizedData,
         Environment: Object {
@@ -1858,6 +1944,117 @@ Object {
         ],
       },
       Type: AWS::IAM::Policy,
+    },
+    LogsBucket9C4D8843: Object {
+      DeletionPolicy: Retain,
+      Metadata: Object {
+        cdk_nag: Object {
+          rules_to_suppress: Array [
+            Object {
+              id: AwsSolutions-S1,
+              reason: Used to store access logs for other buckets,
+            },
+            Object {
+              id: AwsSolutions-S10,
+              reason: Bucket is private and is not using HTTP,
+            },
+          ],
+        },
+        cfn_nag: Object {
+          rules_to_suppress: Array [
+            Object {
+              id: W35,
+              reason: Used to store access logs for other buckets,
+            },
+            Object {
+              id: W51,
+              reason: Bucket is private and does not need a bucket policy,
+            },
+          ],
+        },
+      },
+      Properties: Object {
+        BucketEncryption: Object {
+          ServerSideEncryptionConfiguration: Array [
+            Object {
+              ServerSideEncryptionByDefault: Object {
+                SSEAlgorithm: AES256,
+              },
+            },
+          ],
+        },
+        OwnershipControls: Object {
+          Rules: Array [
+            Object {
+              ObjectOwnership: ObjectWriter,
+            },
+          ],
+        },
+        PublicAccessBlockConfiguration: Object {
+          BlockPublicAcls: true,
+          BlockPublicPolicy: true,
+          IgnorePublicAcls: true,
+          RestrictPublicBuckets: true,
+        },
+        Tags: Array [
+          Object {
+            Key: SolutionId,
+            Value: SO0013,
+          },
+        ],
+        VersioningConfiguration: Object {
+          Status: Enabled,
+        },
+      },
+      Type: AWS::S3::Bucket,
+      UpdateReplacePolicy: Retain,
+    },
+    LogsBucketPolicyD70D9252: Object {
+      Properties: Object {
+        Bucket: Object {
+          Ref: LogsBucket9C4D8843,
+        },
+        PolicyDocument: Object {
+          Statement: Array [
+            Object {
+              Action: s3:*,
+              Condition: Object {
+                Bool: Object {
+                  aws:SecureTransport: false,
+                },
+              },
+              Effect: Deny,
+              Principal: Object {
+                AWS: *,
+              },
+              Resource: Array [
+                Object {
+                  Fn::GetAtt: Array [
+                    LogsBucket9C4D8843,
+                    Arn,
+                  ],
+                },
+                Object {
+                  Fn::Join: Array [
+                    ,
+                    Array [
+                      Object {
+                        Fn::GetAtt: Array [
+                          LogsBucket9C4D8843,
+                          Arn,
+                        ],
+                      },
+                      /*,
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          Version: 2012-10-17,
+        },
+      },
+      Type: AWS::S3::BucketPolicy,
     },
     MediaLiveChannel: Object {
       DeletionPolicy: Delete,


### PR DESCRIPTION
*Issue #, if available:*
An upcoming update on AWS S3 restricts that Bucket cannot have ACLs set with ObjectOwnership's
BucketOwnerEnforced setting.
To remediate this issue, the log bucket is updated to include ObjectWriter as part of the OwnershipControls.
Additionally, github workflow changes and security vulnerabilities are fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
