### PR TITLE
Release v4.2.17- Security updates for npm packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.17] - 2026-03-31
+
+### Security
+
+- Security updates for npm packages
+
 ## [4.2.16] - 2026-03-10
 
 ### Changed

--- a/solution-manifest.yaml
+++ b/solution-manifest.yaml
@@ -1,6 +1,6 @@
 id: SO9671
 name: live-streaming-on-aws
-version: v4.2.16
+version: v4.2.17
 cloudformation_templates:
   - template: live-streaming-on-aws.template
     main_template: true

--- a/source/constructs/package.json
+++ b/source/constructs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "live-streaming-on-aws",
-  "version": "4.2.16",
+  "version": "4.2.17",
   "description": "cdk construct for the live streaming on aws solution",
   "bin": {
     "live-stream": "bin/live-streaming.js"

--- a/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
+++ b/source/constructs/test/__snapshots__/live-streaming.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`LiveStreaming Stack Test 1`] = `
 {
-  Description: (SO0013) Live Streaming on AWS Solution %%VERSION%%,
+  Description: (SO9671) Live Streaming on AWS Solution %%VERSION%%,
   Mappings: {
     AnonymizedData: {
       SendAnonymizedData: {
@@ -1427,6 +1427,14 @@ exports[`LiveStreaming Stack Test 1`] = `
         CustomResourceRoleAB1EF463,
       ],
       Metadata: {
+        cdk_nag: {
+          rules_to_suppress: [
+            {
+              id: AwsSolutions-L1,
+              reason: Lambda function is using the latest runtime version (NODEJS_22_X),
+            },
+          ],
+        },
         cfn_nag: {
           rules_to_suppress: [
             {
@@ -1449,7 +1457,7 @@ exports[`LiveStreaming Stack Test 1`] = `
           S3Bucket: {
             Fn::Sub: cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region},
           },
-          S3Key: e95e115b3d78c42c32e943a86b7323bcaa29c1644db426feb9a2803cb07a8bec.zip,
+          S3Key: ecdc06aad19503bca42f9fc9847ab603c4d8fcc84dae395bb06ca8fa56781b5e.zip,
         },
         Description: Used to deploy custom resources and send AnonymizedData,
         Environment: {


### PR DESCRIPTION
## [4.2.17] - 2026-03-31

### Security

- Security updates for npm packages

### Details

- Bumped version to 4.2.17 in `package.json`, `solution-manifest.yaml`, and `CHANGELOG.md`
- Refreshed npm dependencies
- Updated CDK snapshot to reflect current template state
- All unit tests passing (constructs: 1/1, custom-resource: 30/30)
